### PR TITLE
Add GitHub Actions workflow to deploy Next.js static export to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,53 @@
+name: Deploy static Next.js site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static export
+        run: npm run build
+
+      - name: Disable Jekyll
+        run: touch out/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -14,55 +14,25 @@ Modern, privacy-focused website for [theshieldit.com](https://theshieldit.com)
 
 ## 🚀 Deployment to GitHub Pages
 
-1. **Create a new repository** on GitHub (e.g., `theshieldit-website`)
+This repo is now a **Next.js static export** and should be deployed with **GitHub Actions** (not “Deploy from branch”).
 
-2. **Clone the repository**:
-   ```bash
-   git clone https://github.com/yourusername/theshieldit-website.git
-   cd theshieldit-website
-   ```
+1. Push to `main`.
+2. In GitHub, go to **Settings → Pages**.
+3. Under **Build and deployment**, set **Source** to **GitHub Actions**.
+4. The included workflow (`.github/workflows/deploy-pages.yml`) will:
+   - run `npm ci`
+   - run `npm run build` (exports static files to `out/`)
+   - publish `out/` to Pages
 
-3. **Add the index.html file** to the repository
+### Custom Domain Setup (theshieldit.com)
 
-4. **Commit and push**:
-   ```bash
-   git add .
-   git commit -m "Initial commit: Modern privacy-focused website"
-   git push origin main
-   ```
-
-5. **Enable GitHub Pages**:
-   - Go to your repository settings
-   - Navigate to "Pages" in the left sidebar
-   - Under "Source", select "main" branch and "/ (root)" folder
-   - Click "Save"
-   - Your site will be available at `https://yourusername.github.io/theshieldit-website/`
-
-6. **Custom Domain Setup** (for theshieldit.com):
-   - In repository settings → Pages, add `theshieldit.com` under "Custom domain"
-   - In your domain registrar (Carrd, GoDaddy, etc.), add these DNS records:
-     ```
-     Type: A
-     Name: @
-     Value: 185.199.108.153
-     
-     Type: A
-     Name: @
-     Value: 185.199.109.153
-     
-     Type: A
-     Name: @
-     Value: 185.199.110.153
-     
-     Type: A
-     Name: @
-     Value: 185.199.111.153
-     
-     Type: CNAME
-     Name: www
-     Value: yourusername.github.io
-     ```
-
+- Keep `CNAME` in the repo root (already present).
+- In your DNS provider, point the root domain to GitHub Pages with these `A` records:
+  - `185.199.108.153`
+  - `185.199.109.153`
+  - `185.199.110.153`
+  - `185.199.111.153`
+- Add `www` as a CNAME to `<your-github-username>.github.io`.
 ## 🎨 Customization
 
 ### Updating Social Links


### PR DESCRIPTION
### Motivation
- The repository is a Next.js app configured with `output: "export"`, so GitHub Pages needs the static export produced by `next build` to serve the site correctly. 
- Branch/root publishing on Pages does not run the Next.js build and Jekyll can block underscore-prefixed assets like `_next`, preventing the site from working when moved from Vercel.

### Description
- Add a GitHub Actions workflow file `.github/workflows/deploy-pages.yml` that installs dependencies, runs `npm run build`, adds `out/.nojekyll`, uploads the `out/` artifact, and deploys via `actions/deploy-pages@v4`.
- Ensure Jekyll is disabled for the export by creating `out/.nojekyll` in the workflow so `_next` assets are served correctly.
- Update `README.md` deployment instructions to document that the repo is a Next.js static export and to use GitHub Pages with the repository’s GitHub Actions workflow as the build source while keeping the `CNAME` and DNS guidance for `theshieldit.com`.

### Testing
- Ran `npm run build` locally, which completed successfully and produced the static export (build output shows pages were prerendered and `Exporting` completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5f1efd148325936a4f5bfc86031a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated continuous deployment to GitHub Pages with workflow triggered on pushes to main

* **Documentation**
  * Updated GitHub Pages deployment setup instructions to use new automated workflow
  * Improved custom domain configuration documentation with clearer DNS and CNAME guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->