### PR TITLE
Fix deploy workflow to use pnpm instead of npm ci

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,7 +46,9 @@ jobs:
           fi
 
       - name: Disable Jekyll
-        run: touch out/.nojekyll
+        run: |
+          test -d out || { echo "Build did not produce ./out (check next.config output: 'export')"; exit 1; }
+          touch out/.nojekyll
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,16 +25,31 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build static export
-        run: npm run build
+      - name: Install dependencies and build static export
+        run: |
+          set -euo pipefail
+          if [ -f pnpm-lock.yaml ]; then
+            corepack enable
+            pnpm install --frozen-lockfile
+            pnpm run build
+          elif [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+            npm run build
+          elif [ -f yarn.lock ]; then
+            corepack enable
+            yarn install --frozen-lockfile
+            yarn build
+          else
+            echo "No supported lockfile found (pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json, yarn.lock)."
+            exit 1
+          fi
 
       - name: Disable Jekyll
         run: touch out/.nojekyll
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "theshieldit",
   "version": "1.0.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "gen:tools": "node scripts/gen-tools-map.mjs",
     "predev": "node scripts/gen-tools-map.mjs",


### PR DESCRIPTION
The project uses pnpm (pnpm-lock.yaml), but the workflow was calling
npm ci which requires package-lock.json and fails immediately. This
caused every GitHub Actions deploy to fail silently, leaving GitHub
Pages serving the repository README instead of the built site.

Replaces the hardcoded npm ci/build steps with lockfile-aware detection
(pnpm → npm → yarn) and adds the configure-pages step.

https://claude.ai/code/session_01QG3qURHvUyGUMFAvGfkfwh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the deployment workflow by consolidating build steps into a single automated process.
  * Added support for multiple package managers (pnpm, npm, yarn) with automatic detection and fallback logic.
  * Enhanced GitHub Pages configuration in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->